### PR TITLE
disable warning for unused function

### DIFF
--- a/cuda/include/dbscan/CudaUtils.cuh
+++ b/cuda/include/dbscan/CudaUtils.cuh
@@ -20,7 +20,7 @@ cudaError_t warmUpGPU();
 }  // namespace utils
 }  // namespace cuda
 
-static void HandleError(cudaError_t err, const char* file, int line)
+inline void HandleError(cudaError_t err, const char* file, int line)
 {
     if (err != cudaSuccess) {
         printf("%s in %s at line %d\n", cudaGetErrorString(err), file, line);


### PR DESCRIPTION
@HMX2013
This would fix the warning issue in https://github.com/xmba15/generic_dbscan/issues/5